### PR TITLE
New Documentation page added (new page + two visuals) and set as the …

### DIFF
--- a/Sales.Report/definition/pages/2821e1071a68cf55b7bd/page.json
+++ b/Sales.Report/definition/pages/2821e1071a68cf55b7bd/page.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/2.0.0/schema.json",
+  "name": "2821e1071a68cf55b7bd",
+  "displayName": "Documentation",
+  "displayOption": "FitToPage",
+  "height": 720,
+  "width": 1280
+}

--- a/Sales.Report/definition/pages/2821e1071a68cf55b7bd/visuals/9dc416aef878f7f964ce/visual.json
+++ b/Sales.Report/definition/pages/2821e1071a68cf55b7bd/visuals/9dc416aef878f7f964ce/visual.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.5.0/schema.json",
+  "name": "9dc416aef878f7f964ce",
+  "position": {
+    "x": 1082.4161073825503,
+    "y": 0,
+    "z": 1,
+    "height": 166.90316395014381,
+    "width": 197.58389261744966,
+    "tabOrder": 1
+  },
+  "visual": {
+    "visualType": "slicer",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Model Documentation"
+                    }
+                  },
+                  "Property": "Type"
+                }
+              },
+              "queryRef": "Model Documentation.Type",
+              "nativeQueryRef": "Type",
+              "active": true
+            }
+          ]
+        }
+      }
+    },
+    "objects": {
+      "data": [
+        {
+          "properties": {
+            "mode": {
+              "expr": {
+                "Literal": {
+                  "Value": "'Basic'"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "drillFilterOtherVisuals": true
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "82faba997de27a09585b",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Model Documentation"
+              }
+            },
+            "Property": "Type"
+          }
+        },
+        "type": "Categorical"
+      }
+    ]
+  }
+}

--- a/Sales.Report/definition/pages/2821e1071a68cf55b7bd/visuals/c9c62a1355668f5554c4/visual.json
+++ b/Sales.Report/definition/pages/2821e1071a68cf55b7bd/visuals/c9c62a1355668f5554c4/visual.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.5.0/schema.json",
+  "name": "c9c62a1355668f5554c4",
+  "position": {
+    "x": 9.8178331735378723,
+    "y": 17.181208053691275,
+    "z": 0,
+    "height": 656.56759348034518,
+    "width": 695.83892617449669,
+    "tabOrder": 0
+  },
+  "visual": {
+    "visualType": "tableEx",
+    "query": {
+      "queryState": {
+        "Values": {
+          "projections": [
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Model Documentation"
+                    }
+                  },
+                  "Property": "Name"
+                }
+              },
+              "queryRef": "Model Documentation.Name",
+              "nativeQueryRef": "Name"
+            },
+            {
+              "field": {
+                "Column": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Model Documentation"
+                    }
+                  },
+                  "Property": "Type"
+                }
+              },
+              "queryRef": "Model Documentation.Type",
+              "nativeQueryRef": "Type"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Model Documentation"
+                    }
+                  },
+                  "Property": "# of Columns"
+                }
+              },
+              "queryRef": "Model Documentation.# of Columns",
+              "nativeQueryRef": "# of Columns"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Model Documentation"
+                    }
+                  },
+                  "Property": "# of Measures"
+                }
+              },
+              "queryRef": "Model Documentation.# of Measures",
+              "nativeQueryRef": "# of Measures"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Model Documentation"
+                    }
+                  },
+                  "Property": "# of Relationship"
+                }
+              },
+              "queryRef": "Model Documentation.# of Relationship",
+              "nativeQueryRef": "# of Relationship"
+            },
+            {
+              "field": {
+                "Measure": {
+                  "Expression": {
+                    "SourceRef": {
+                      "Entity": "Model Documentation"
+                    }
+                  },
+                  "Property": "# of Tables"
+                }
+              },
+              "queryRef": "Model Documentation.# of Tables",
+              "nativeQueryRef": "# of Tables"
+            }
+          ]
+        }
+      }
+    },
+    "drillFilterOtherVisuals": true
+  },
+  "filterConfig": {
+    "filters": [
+      {
+        "name": "091dda992a4082f19daa",
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Model Documentation"
+              }
+            },
+            "Property": "# of Columns"
+          }
+        },
+        "type": "Advanced"
+      },
+      {
+        "name": "fdf8a614ec7bd35d5a0b",
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Model Documentation"
+              }
+            },
+            "Property": "# of Measures"
+          }
+        },
+        "type": "Advanced"
+      },
+      {
+        "name": "f51d6c00c5cc59150bff",
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Model Documentation"
+              }
+            },
+            "Property": "# of Relationship"
+          }
+        },
+        "type": "Advanced"
+      },
+      {
+        "name": "d63b860f4da99097c192",
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Model Documentation"
+              }
+            },
+            "Property": "# of Tables"
+          }
+        },
+        "type": "Advanced"
+      },
+      {
+        "name": "8091292908a33e085610",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Model Documentation"
+              }
+            },
+            "Property": "Name"
+          }
+        },
+        "type": "Categorical"
+      },
+      {
+        "name": "c62586d3ccf3b5b12f28",
+        "field": {
+          "Column": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Model Documentation"
+              }
+            },
+            "Property": "Type"
+          }
+        },
+        "type": "Categorical"
+      }
+    ]
+  }
+}

--- a/Sales.Report/definition/pages/ReportSection89a9619c7025093ade1c/visuals/8b8727ff328bdc49692c/visual.json
+++ b/Sales.Report/definition/pages/ReportSection89a9619c7025093ade1c/visuals/8b8727ff328bdc49692c/visual.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.4.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.5.0/schema.json",
   "name": "8b8727ff328bdc49692c",
   "position": {
     "x": 942.79569892473114,
@@ -58,7 +58,7 @@
             "startDate": {
               "expr": {
                 "Literal": {
-                  "Value": "datetime'2022-01-01T00:00:00'"
+                  "Value": "datetime'2023-01-01T00:00:00'"
                 }
               }
             }
@@ -95,7 +95,7 @@
                         },
                         "Right": {
                           "Literal": {
-                            "Value": "datetime'2022-01-01T00:00:00'"
+                            "Value": "datetime'2023-01-01T00:00:00'"
                           }
                         }
                       }

--- a/Sales.Report/definition/pages/ReportSection89a9619c7025093ade1c/visuals/eb5c360e357e8b54eb88/visual.json
+++ b/Sales.Report/definition/pages/ReportSection89a9619c7025093ade1c/visuals/eb5c360e357e8b54eb88/visual.json
@@ -2,11 +2,11 @@
   "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.4.0/schema.json",
   "name": "eb5c360e357e8b54eb88",
   "position": {
-    "x": 106.30042918454936,
-    "y": 8.0343347639484985,
+    "x": 106.74017918676775,
+    "y": 7.9393521709166093,
     "z": 10000,
-    "height": 62.4206008583691,
-    "width": 585.27038626609442,
+    "height": 62.632667126119919,
+    "width": 670.43418332184706,
     "tabOrder": 10000
   },
   "visual": {

--- a/Sales.Report/definition/pages/ReportSectiond90903559771e58905a1/visuals/477e4ffc7bd2ba217c85/visual.json
+++ b/Sales.Report/definition/pages/ReportSectiond90903559771e58905a1/visuals/477e4ffc7bd2ba217c85/visual.json
@@ -2,11 +2,11 @@
   "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.4.0/schema.json",
   "name": "477e4ffc7bd2ba217c85",
   "position": {
-    "x": 106.30042918454936,
-    "y": 8.0343347639484985,
+    "x": 106.74017918676775,
+    "y": 7.9393521709166093,
     "z": 10000,
-    "height": 62.4206008583691,
-    "width": 585.27038626609442,
+    "height": 62.632667126119919,
+    "width": 658.96623018607863,
     "tabOrder": 10000
   },
   "visual": {
@@ -27,7 +27,7 @@
                     }
                   },
                   {
-                    "value": "Geo Analysis",
+                    "value": "Geo Analysis - changes",
                     "textStyle": {
                       "fontWeight": "bold",
                       "fontFamily": "Segoe (Bold)",

--- a/Sales.Report/definition/pages/ReportSectiond90903559771e58905a1/visuals/b5f2ce8ee65990353917/visual.json
+++ b/Sales.Report/definition/pages/ReportSectiond90903559771e58905a1/visuals/b5f2ce8ee65990353917/visual.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.4.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualContainer/2.5.0/schema.json",
   "name": "b5f2ce8ee65990353917",
   "position": {
     "x": 702.88638689866934,
@@ -240,6 +240,20 @@
             }
           ]
         }
+      },
+      {
+        "name": "2cae7a70fa2f62f12039",
+        "field": {
+          "Measure": {
+            "Expression": {
+              "SourceRef": {
+                "Entity": "Sales"
+              }
+            },
+            "Property": "# Customers (with Sales)"
+          }
+        },
+        "type": "Advanced"
       }
     ],
     "filterSortOrder": "Custom"

--- a/Sales.Report/definition/pages/pages.json
+++ b/Sales.Report/definition/pages/pages.json
@@ -5,7 +5,8 @@
     "ReportSectiond90903559771e58905a1",
     "ReportSection8a2d1e93c8442763827c",
     "ReportSection61481e08c8c340011ce0",
-    "ReportSection6687c48ea8a9b7740002"
+    "ReportSection6687c48ea8a9b7740002",
+    "2821e1071a68cf55b7bd"
   ],
-  "activePageName": "ReportSectiond90903559771e58905a1"
+  "activePageName": "2821e1071a68cf55b7bd"
 }

--- a/Sales.Report/definition/pages/pages.json
+++ b/Sales.Report/definition/pages/pages.json
@@ -8,5 +8,5 @@
     "ReportSection6687c48ea8a9b7740002",
     "2821e1071a68cf55b7bd"
   ],
-  "activePageName": "2821e1071a68cf55b7bd"
+  "activePageName": "ReportSection89a9619c7025093ade1c"
 }

--- a/Sales.Report/definition/report.json
+++ b/Sales.Report/definition/report.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/3.0.0/schema.json",
+  "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/3.1.0/schema.json",
   "themeCollection": {
     "baseTheme": {
       "name": "CY23SU04",
@@ -20,64 +20,6 @@
       "type": "RegisteredResources"
     }
   },
-  "filterConfig": {
-    "filters": [
-      {
-        "name": "ac446278e7fc4c931ec2",
-        "field": {
-          "Column": {
-            "Expression": {
-              "SourceRef": {
-                "Entity": "Calendar"
-              }
-            },
-            "Property": "Year"
-          }
-        },
-        "type": "Categorical",
-        "filter": {
-          "Version": 2,
-          "From": [
-            {
-              "Name": "c",
-              "Entity": "Calendar",
-              "Type": 0
-            }
-          ],
-          "Where": [
-            {
-              "Condition": {
-                "In": {
-                  "Expressions": [
-                    {
-                      "Column": {
-                        "Expression": {
-                          "SourceRef": {
-                            "Source": "c"
-                          }
-                        },
-                        "Property": "Year"
-                      }
-                    }
-                  ],
-                  "Values": [
-                    [
-                      {
-                        "Literal": {
-                          "Value": "2023L"
-                        }
-                      }
-                    ]
-                  ]
-                }
-              }
-            }
-          ]
-        },
-        "howCreated": "User"
-      }
-    ]
-  },
   "objects": {
     "outspacePane": [
       {
@@ -85,7 +27,7 @@
           "expanded": {
             "expr": {
               "Literal": {
-                "Value": "false"
+                "Value": "true"
               }
             }
           },


### PR DESCRIPTION
…active page.

Report and visual schema versions bumped (report 3.0.0→3.1.0; several visuals 2.4.0→2.5.0). Date slicer updated from 2022-01-01 → 2023-01-01.
Top-level Year filter removed from report.json (functional change to default filtering). Minor visual/layout/text tweaks (textbox labels appended " - changes"; position/size adjustments; added a measure filter for # Customers (with Sales)).

Closes #2